### PR TITLE
Chart gets destroyed when it's removed from the DOM

### DIFF
--- a/projects/seatsio-angular/src/lib/seatsio-angular.module.ts
+++ b/projects/seatsio-angular/src/lib/seatsio-angular.module.ts
@@ -1,8 +1,8 @@
-import { NgModule } from '@angular/core';
-import { SeatsioDesignerComponent } from './seatsio-designer/seatsio-designer.component';
-import { SeatsioSeatingChartComponent } from './seatsio-seating-chart/seatsio-seating-chart.component';
-import { SeatsioEventManagerComponent } from './seatsio-event-manager/seatsio-event-manager.component';
-import { SeatsioChartManagerComponent } from './seatsio-chart-manager/seatsio-chart-manager.component';
+import {NgModule} from '@angular/core';
+import {SeatsioDesignerComponent} from './seatsio-designer/seatsio-designer.component';
+import {SeatsioSeatingChartComponent} from './seatsio-seating-chart/seatsio-seating-chart.component';
+import {SeatsioEventManagerComponent} from './seatsio-event-manager/seatsio-event-manager.component';
+import {SeatsioChartManagerComponent} from './seatsio-chart-manager/seatsio-chart-manager.component';
 
 @NgModule({
   declarations: [
@@ -18,4 +18,5 @@ import { SeatsioChartManagerComponent } from './seatsio-chart-manager/seatsio-ch
     SeatsioChartManagerComponent
   ]
 })
-export class SeatsioAngularModule { }
+export class SeatsioAngularModule {
+}

--- a/projects/seatsio-angular/src/lib/seatsio-chart-manager/seatsio-chart-manager.component.ts
+++ b/projects/seatsio-angular/src/lib/seatsio-chart-manager/seatsio-chart-manager.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit, Input } from '@angular/core';
+import {Component} from '@angular/core';
 import {SeatsioService} from '../seatsio.service';
+import {SeatsioComponent} from '../seatsio.component';
 
 @Component({
   selector: 'si-seatsio-chart-manager',
@@ -7,25 +8,13 @@ import {SeatsioService} from '../seatsio.service';
   styleUrls: ['./seatsio-chart-manager.component.css'],
   providers: [SeatsioService]
 })
-export class SeatsioChartManagerComponent implements OnInit {
-  @Input() id: String = 'chart';
-  @Input() config: object;
-  @Input() class: String;
-
-  seatsioService: SeatsioService;
+export class SeatsioChartManagerComponent extends SeatsioComponent {
 
   constructor(seatsioService: SeatsioService) {
-    this.seatsioService = seatsioService;
+    super(seatsioService);
   }
 
-  ngOnInit() {
-    if (this.config['divId']) {
-      this.id = this.config['divId'];
-    }
-
-    if ('onRenderStarted' in this.config) this.config['onRenderStarted']()
-
-    this.seatsioService.showChartManager(this.config);
+  protected render(config: any) {
+    return this.seatsioService.showChartManager(config);
   }
-
 }

--- a/projects/seatsio-angular/src/lib/seatsio-designer/seatsio-designer.component.ts
+++ b/projects/seatsio-angular/src/lib/seatsio-designer/seatsio-designer.component.ts
@@ -1,5 +1,6 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component} from '@angular/core';
 import {SeatsioService} from '../seatsio.service';
+import {SeatsioComponent} from '../seatsio.component';
 
 @Component({
   selector: 'si-seatsio-designer',
@@ -7,25 +8,13 @@ import {SeatsioService} from '../seatsio.service';
   styleUrls: ['./seatsio-designer.component.css'],
   providers: [SeatsioService]
 })
-export class SeatsioDesignerComponent implements OnInit {
-  @Input() id: String = 'chart';
-  @Input() config: object;
-  @Input() class: String;
-
-  seatsioService: SeatsioService;
+export class SeatsioDesignerComponent extends SeatsioComponent {
 
   constructor(seatsioService: SeatsioService) {
-    this.seatsioService = seatsioService;
+    super(seatsioService);
   }
 
-  ngOnInit() {
-
-    if (this.config['divId']) {
-      this.id = this.config['divId'];
-    }
-
-    if ('onRenderStarted' in this.config) { this.config['onRenderStarted'](); }
-
-    this.seatsioService.showDesigner(this.config);
+  protected render(config: any) {
+    return this.seatsioService.showDesigner(this.config);
   }
 }

--- a/projects/seatsio-angular/src/lib/seatsio-event-manager/seatsio-event-manager.component.ts
+++ b/projects/seatsio-angular/src/lib/seatsio-event-manager/seatsio-event-manager.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit, Input } from '@angular/core';
+import {Component} from '@angular/core';
 import {SeatsioService} from '../seatsio.service';
+import {SeatsioComponent} from '../seatsio.component';
 
 @Component({
   selector: 'si-seatsio-event-manager',
@@ -7,25 +8,13 @@ import {SeatsioService} from '../seatsio.service';
   styleUrls: ['./seatsio-event-manager.component.css'],
   providers: [SeatsioService]
 })
-export class SeatsioEventManagerComponent implements OnInit {
-  @Input() id: String = 'chart';
-  @Input() config: object;
-  @Input() class: String;
-
-  seatsioService: SeatsioService;
+export class SeatsioEventManagerComponent extends SeatsioComponent {
 
   constructor(seatsioService: SeatsioService) {
-    this.seatsioService = seatsioService;
+    super(seatsioService);
   }
 
-  ngOnInit() {
-    if (this.config['divId']) {
-      this.id = this.config['divId'];
-    }
-
-    if ('onRenderStarted' in this.config) this.config['onRenderStarted']()
-
-    this.seatsioService.showEventManager(this.config);
+  protected render(config: any) {
+    return this.seatsioService.showEventManager(this.config);
   }
-
 }

--- a/projects/seatsio-angular/src/lib/seatsio-seating-chart/seatsio-seating-chart.component.ts
+++ b/projects/seatsio-angular/src/lib/seatsio-seating-chart/seatsio-seating-chart.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit, Input } from '@angular/core';
+import {Component} from '@angular/core';
 import {SeatsioService} from '../seatsio.service';
+import {SeatsioComponent} from '../seatsio.component';
 
 @Component({
   selector: 'si-seatsio-seating-chart',
@@ -7,27 +8,13 @@ import {SeatsioService} from '../seatsio.service';
   styleUrls: ['./seatsio-seating-chart.component.css'],
   providers: [SeatsioService]
 })
-export class SeatsioSeatingChartComponent implements OnInit {
-  @Input() id: String = 'chart';
-  @Input() config: object;
-  @Input() class: String;
-
-
-  seatsioService: SeatsioService;
+export class SeatsioSeatingChartComponent extends SeatsioComponent {
 
   constructor(seatsioService: SeatsioService) {
-    this.seatsioService = seatsioService;
+    super(seatsioService);
   }
 
-  ngOnInit() {
-    if (this.config['divId']) {
-      this.id = this.config['divId'];
-    }
-
-    if ('onRenderStarted' in this.config) this.config['onRenderStarted']()
-
-    this.seatsioService.showSeatingChart(this.config);
-
+  protected render(config: any) {
+    return this.seatsioService.showSeatingChart(this.config);
   }
-
 }

--- a/projects/seatsio-angular/src/lib/seatsio.component.ts
+++ b/projects/seatsio-angular/src/lib/seatsio.component.ts
@@ -1,0 +1,36 @@
+import {Component, Input, OnDestroy, OnInit} from '@angular/core';
+import {SeatsioService} from './seatsio.service';
+
+@Component({ template: '' })
+export abstract class SeatsioComponent implements OnInit, OnDestroy {
+  @Input() id: String = 'chart';
+  @Input() config: object;
+  @Input() class: String;
+
+  seatsioService: SeatsioService;
+  chart: any;
+
+  constructor(seatsioService: SeatsioService) {
+    this.seatsioService = seatsioService;
+  }
+
+  protected abstract render(config: any);
+
+  async ngOnInit() {
+    if (this.config['divId']) {
+      this.id = this.config['divId'];
+    }
+
+    if ('onRenderStarted' in this.config) {
+      this.config['onRenderStarted']();
+    }
+
+    this.chart = await this.render(this.config);
+  }
+
+  ngOnDestroy() {
+    if (this.chart) {
+      this.chart.destroy();
+    }
+  }
+}

--- a/projects/seatsio-angular/src/lib/seatsio.service.ts
+++ b/projects/seatsio-angular/src/lib/seatsio.service.ts
@@ -13,8 +13,7 @@ export class SeatsioService implements OnInit, OnDestroy {
 
     delete config['chartJsUrl'];
     delete config['region'];
-    const chart = new seatsioInstance.SeatingChartDesigner(config).render();
-    return chart;
+    return new seatsioInstance.SeatingChartDesigner(config).render();
   }
 
   async showSeatingChart(config) {
@@ -22,8 +21,7 @@ export class SeatsioService implements OnInit, OnDestroy {
 
     delete config['chartJsUrl'];
     delete config['region'];
-    const chart = new seatsioInstance.SeatingChart(config).render();
-    return chart;
+    return new seatsioInstance.SeatingChart(config).render();
   }
 
   async showEventManager(config) {
@@ -31,8 +29,7 @@ export class SeatsioService implements OnInit, OnDestroy {
 
     delete config['chartJsUrl'];
     delete config['region'];
-    const chart = new seatsioInstance.EventManager(config).render();
-    return chart;
+    return new seatsioInstance.EventManager(config).render();
   }
 
   async showChartManager(config) {
@@ -40,8 +37,7 @@ export class SeatsioService implements OnInit, OnDestroy {
 
     delete config['chartJsUrl'];
     delete config['region'];
-    const chart = new seatsioInstance.ChartManager(config).render();
-    return chart;
+    return new seatsioInstance.ChartManager(config).render();
   }
 
   getSeatsio(region, chartJsUrl) {

--- a/projects/testApp/src/app/app.component.html
+++ b/projects/testApp/src/app/app.component.html
@@ -15,21 +15,28 @@
 <div class="showDesigner">
   <!--<si-seatsio-designer
     class="designer"
-    [config]="designerConfig"
+    [config]="designerConfig()"
+    *ngIf="shown"
   ></si-seatsio-designer>-->
 
-  <!--<si-seatsio-seating-chart
+  <si-seatsio-seating-chart
     class="designer"
-    [config]="seatingChartConfig"
-  ></si-seatsio-seating-chart>-->
+    [config]="seatingChartConfig()"
+    *ngIf="shown"
+  ></si-seatsio-seating-chart>
 
   <!--<si-seatsio-event-manager
     class="designer"
-    [config]="eventManagerConfig"
+    [config]="eventManagerConfig()"
+    *ngIf="shown"
   ></si-seatsio-event-manager>-->
 
-  <si-seatsio-chart-manager
+  <!--si-seatsio-chart-manager
     class="designer"
-    [config]="chartManagerConfig"
-  ></si-seatsio-chart-manager>
+    [config]="chartManagerConfig()"
+    *ngIf="shown"
+  ></si-seatsio-chart-manager-->
+
 </div>
+
+<button (click)="onToggle()">Toggle</button>

--- a/projects/testApp/src/app/app.component.ts
+++ b/projects/testApp/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   selector: 'app-root',
@@ -7,49 +7,54 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'Seatsio-angular test page';
+  shown = true;
 
-  designerConfig = {
-    class: "designer",
-    designerKey: "demoDesignerKey",
-    chartJsUrl: "https://cdn-staging-{region}.seatsio.net/chart.js",
-    region: "eu",
-    onExitRequested: () => console.log("Exit Requested"),
-    onChartCreated: key => console.log("Chart Created", key)
-  }
+  designerConfig = () => ({
+    class: 'designer',
+    designerKey: 'demoDesignerKey',
+    chartJsUrl: 'https://cdn-staging-{region}.seatsio.net/chart.js',
+    region: 'eu',
+    onExitRequested: () => console.log('Exit Requested'),
+    onChartCreated: key => console.log('Chart Created', key)
+  });
 
-  seatingChartConfig = {
-    publicKey: "publicDemoKey",
-    chartJsUrl: "https://cdn-staging-{region}.seatsio.net/chart.js",
-    region: "eu",
-    event: "fullExampleWithoutSectionsEvent",
+  seatingChartConfig = () => ({
+    publicKey: 'publicDemoKey',
+    chartJsUrl: 'https://cdn-staging-{region}.seatsio.net/chart.js',
+    region: 'eu',
+    event: 'fullExampleWithoutSectionsEvent',
     onRenderStarted: () => {
-      console.info('Render Started')
+      console.info('Render Started');
     },
     onChartRendered: () => {
-      console.info('Render Finished')
+      console.info('Render Finished');
     },
     priceFormatter: price => ('$' + price)
-  }
+  });
 
-  eventManagerConfig = {
-    secretKey: "demoKey",
-    chartJsUrl: "https://cdn-staging-{region}.seatsio.net/chart.js",
-    region: "eu",
-    event: "fullExampleWithoutSectionsEvent",
-    mode: "manageObjectStatuses",
+  eventManagerConfig = () => ({
+    secretKey: 'demoKey',
+    chartJsUrl: 'https://cdn-staging-{region}.seatsio.net/chart.js',
+    region: 'eu',
+    event: 'fullExampleWithoutSectionsEvent',
+    mode: 'manageObjectStatuses',
     onChartRendered: () => {
-      console.info('Render Finished')
+      console.info('Render Finished');
     }
-  }
+  });
 
-  chartManagerConfig = {
-    secretKey: "demoKey",
-    chartJsUrl: "https://cdn-staging-{region}.seatsio.net/chart.js",
-    region: "eu",
-    chart: "demoChartSmallTheatre",
-    mode: "manageRulesets",
+  chartManagerConfig = () => ({
+    secretKey: 'demoKey',
+    chartJsUrl: 'https://cdn-staging-{region}.seatsio.net/chart.js',
+    region: 'eu',
+    chart: 'demoChartSmallTheatre',
+    mode: 'manageRulesets',
     onChartRendered: () => {
-      console.info('Render Finished')
+      console.info('Render Finished');
     },
-  }
+  });
+
+  onToggle = () => {
+    this.shown = !this.shown;
+  };
 }


### PR DESCRIPTION
When Angular removed a chart from the DOM, we didn't clean up. That's now fixed, by invoking `chart.destroy()` from `ngOnDestroy()`.

Also extracted some common code to a base component.