### PR TITLE
Use caret versioning for @seatsio/seatsio-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@angular/platform-browser": "16.1.0",
     "@angular/platform-browser-dynamic": "16.1.0",
     "@angular/router": "16.1.0",
-    "@seatsio/seatsio-types": "^2.5.0"
+    "@seatsio/seatsio-types": "2.6.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "16.2.9",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@angular/platform-browser": "16.1.0",
     "@angular/platform-browser-dynamic": "16.1.0",
     "@angular/router": "16.1.0",
-    "@seatsio/seatsio-types": "2.5.0"
+    "@seatsio/seatsio-types": "^2.5.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "16.2.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,7 +1849,7 @@
     "@angular-devkit/schematics" "17.1.2"
     jsonc-parser "3.2.0"
 
-"@seatsio/seatsio-types@^2.5.0":
+"@seatsio/seatsio-types@2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@seatsio/seatsio-types/-/seatsio-types-2.6.0.tgz#81f7f79222401688ead9cb8dcd8198f688fbdea7"
   integrity sha512-h/1y3b861GW31VVG5wNpuss4zptXV6VHA18UGCWmqjySTcQkc6boUVKwdvwBflt9qSF8mN2w1ykMX5/asX70kw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,10 +1849,10 @@
     "@angular-devkit/schematics" "17.1.2"
     jsonc-parser "3.2.0"
 
-"@seatsio/seatsio-types@2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@seatsio/seatsio-types/-/seatsio-types-2.5.0.tgz#2f30030e046d9100e4e70d0b2ab54f0994277cfe"
-  integrity sha512-yTralQ0coc+sDlwDtAubKWqaMfIXjwjRsQyt/1wZP4bSnn6sxDASzfbzIJMdranMW057wfLYmSPbRp4eneo6xA==
+"@seatsio/seatsio-types@^2.5.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@seatsio/seatsio-types/-/seatsio-types-2.6.0.tgz#81f7f79222401688ead9cb8dcd8198f688fbdea7"
+  integrity sha512-h/1y3b861GW31VVG5wNpuss4zptXV6VHA18UGCWmqjySTcQkc6boUVKwdvwBflt9qSF8mN2w1ykMX5/asX70kw==
 
 "@sigstore/bundle@^2.1.0":
   version "2.1.0"


### PR DESCRIPTION
Sets the version of `@seatsio/seatsio-types` to `^2.5.0`, so that updating the package will always give the last published 2.X version of types.