### PR TITLE
Update @seatsio/seatsio-types to v6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@angular/platform-browser": "16.1.0",
     "@angular/platform-browser-dynamic": "16.1.0",
     "@angular/router": "16.1.0",
-    "@seatsio/seatsio-types": "5.10.0"
+    "@seatsio/seatsio-types": "v6.1.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "16.2.9",


### PR DESCRIPTION
This PR updates @seatsio/seatsio-types from 5.10.0 to v6.1.0.

## Changes
- Updated @seatsio/seatsio-types dependency to latest version
- Ensures compatibility with latest SeatsIO type definitions

## Testing
Please verify that all existing functionality works as expected with the updated types.

---
*This PR was created automatically by the SeatsIO Types Manager.*